### PR TITLE
Change return type and unit syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ fn main() unit = {
 - Automatic, deterministic memory management
 - Pattern matching and tagged union types
 - Parametric polymorphism and distinct typing
+- Local type inference with required top level type annotations
 - Compiled to machine code (Currently compile to C)
 
 ## Goals

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Jin is a statically typed, procedural and safe programming language.
 ## Hello, World
 
 ```
-fn main() = {
+fn main() unit = {
     println("Hello, World!")
 }
 ```

--- a/README.md
+++ b/README.md
@@ -12,16 +12,16 @@ fn main() unit = {
 
 ## Highlights
 
-- Deterministic, automatic memory management
-- Pattern matching and union types
-- Polymorphic types
-- Compiled
+- Automatic, deterministic memory management
+- Pattern matching and tagged union types
+- Parametric polymorphism and distinct typing
+- Compiled to machine code (Currently compile to C)
 
 ## Goals
 
-- Fast enough for use-cases such as servers and cli applications
-- Simple and orthogonal
+- Simple enough that it can be learned in an afternoon
 - Fast compile times
+- Performance that statisfies use-cases such as servers and applications
 
 ## Prerequisites
 

--- a/compiler_ast/src/lib.rs
+++ b/compiler_ast/src/lib.rs
@@ -246,9 +246,6 @@ pub enum Expr {
         kind: CharKind,
         span: Span,
     },
-    UnitLit {
-        span: Span,
-    },
 }
 
 impl Spanned for Expr {
@@ -282,8 +279,7 @@ impl Spanned for Expr {
             | Self::FloatLit { span, .. }
             | Self::StrInterp { span, .. }
             | Self::StrLit { span, .. }
-            | Self::CharLit { span, .. }
-            | Self::UnitLit { span, .. } => *span,
+            | Self::CharLit { span, .. } => *span,
         }
     }
 }

--- a/compiler_ast/src/pretty.rs
+++ b/compiler_ast/src/pretty.rs
@@ -451,11 +451,13 @@ impl PrettyPrint for TyExpr {
 
                 cx.builder.end_child();
             }
-            TyExpr::Unit(_) => {
-                cx.builder.add_empty_child("unit".to_string());
-            }
             TyExpr::Hole(_) => {
                 cx.builder.add_empty_child("_".to_string());
+            }
+            TyExpr::Group(ty, _) => {
+                cx.builder.begin_child("group".to_string());
+                ty.pretty_print(cx);
+                cx.builder.end_child();
             }
         }
     }

--- a/compiler_ast/src/pretty.rs
+++ b/compiler_ast/src/pretty.rs
@@ -414,11 +414,9 @@ impl PrettyPrint for TyExpr {
                     cx.builder.end_child();
                 }
 
-                if let Some(ret) = &f.ret {
-                    cx.builder.begin_child("ret".to_string());
-                    ret.pretty_print(cx);
-                    cx.builder.end_child();
-                }
+                cx.builder.begin_child("ret".to_string());
+                f.ret.pretty_print(cx);
+                cx.builder.end_child();
 
                 cx.builder.end_child();
             }

--- a/compiler_ast/src/pretty.rs
+++ b/compiler_ast/src/pretty.rs
@@ -232,9 +232,6 @@ impl PrettyPrint for Expr {
                     cx.builder.add_empty_child(format!("byte char: {value}"));
                 }
             },
-            Self::UnitLit { .. } => {
-                cx.builder.add_empty_child("unit".to_string());
-            }
         }
     }
 }

--- a/compiler_core/src/middle.rs
+++ b/compiler_core/src/middle.rs
@@ -174,11 +174,11 @@ impl UnOp {
 #[derive(Debug, Clone)]
 pub enum TyExpr {
     Fn(TyExprFn),
-    Slice(Box<TyExpr>, Span),
-    Ref(Box<TyExpr>, Mutability, Span),
-    Path(Vec<Word>, Option<Vec<TyExpr>>, Span),
-    Unit(Span),
+    Slice(Box<Self>, Span),
+    Ref(Box<Self>, Mutability, Span),
+    Path(Vec<Word>, Option<Vec<Self>>, Span),
     Hole(Span),
+    Group(Box<Self>, Span),
 }
 
 impl Spanned for TyExpr {
@@ -188,8 +188,8 @@ impl Spanned for TyExpr {
             | Self::Slice(_, span)
             | Self::Ref(_, _, span)
             | Self::Path(_, _, span)
-            | Self::Unit(span)
-            | Self::Hole(span) => *span,
+            | Self::Hole(span)
+            | Self::Group(_, span) => *span,
         }
     }
 }

--- a/compiler_core/src/middle.rs
+++ b/compiler_core/src/middle.rs
@@ -197,7 +197,7 @@ impl Spanned for TyExpr {
 #[derive(Debug, Clone)]
 pub struct TyExprFn {
     pub params: Vec<TyExpr>,
-    pub ret: Option<Box<TyExpr>>,
+    pub ret: Box<TyExpr>,
     pub is_extern: bool,
     pub is_c_variadic: bool,
     pub callconv: CallConv,

--- a/compiler_core/src/sym.rs
+++ b/compiler_core/src/sym.rs
@@ -18,6 +18,7 @@ pub mod ty {
     pub const STR: &str = "str";
     pub const CHAR: &str = "char";
     pub const BOOL: &str = "bool";
+    pub const UNIT: &str = "unit";
     pub const NEVER: &str = "never";
 }
 

--- a/compiler_parse/src/parser.rs
+++ b/compiler_parse/src/parser.rs
@@ -199,25 +199,25 @@ impl<'a> Parser<'a> {
     }
 
     #[inline]
-    pub(super) fn eat_any(&mut self) -> DiagnosticResult<Token> {
-        let tok = self.require()?;
+    pub(super) fn eat_any(&mut self, expected: &str) -> DiagnosticResult<Token> {
+        let tok = self.require(expected)?;
         self.next();
         Ok(tok)
     }
 
     #[inline]
     pub(super) fn unexpected_token(&mut self, expected: &str) -> Diagnostic {
-        match self.require() {
+        match self.require(expected) {
             Ok(tok) => errors::unexpected_token_err(expected, tok.kind, tok.span),
             Err(diag) => diag,
         }
     }
 
     #[inline]
-    fn require(&mut self) -> DiagnosticResult<Token> {
+    fn require(&mut self, expected: &str) -> DiagnosticResult<Token> {
         self.token().ok_or_else(|| {
-            Diagnostic::error("unexpected end of file")
-                .with_label(Label::primary(self.last_span(), "here"))
+            Diagnostic::error(format!("expected {expected}, found end of file"))
+                .with_label(Label::primary(self.last_span(), "found here"))
         })
     }
 

--- a/compiler_parse/src/parser/expr.rs
+++ b/compiler_parse/src/parser/expr.rs
@@ -82,7 +82,7 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_atom(&mut self) -> DiagnosticResult<Expr> {
-        let tok = self.eat_any()?;
+        let tok = self.eat_any("an expression")?;
 
         let expr = match tok.kind {
             TokenKind::Kw(Kw::Fn) => self.parse_fn_expr()?,
@@ -370,7 +370,7 @@ impl<'a> Parser<'a> {
     ) -> DiagnosticResult<Pat> {
         let mutability = self.parse_mutability();
         let named = allow_named == IsFnParam::Yes && self.is(TokenKind::Tilde);
-        let tok = self.eat_any()?;
+        let tok = self.eat_any("a pattern")?;
 
         match tok.kind {
             TokenKind::Ident(_) => {

--- a/compiler_parse/src/parser/expr.rs
+++ b/compiler_parse/src/parser/expr.rs
@@ -11,7 +11,7 @@ use compiler_core::{
 use compiler_data_structures::index_vec::Key as _;
 use ustr::ustr;
 
-use crate::parser::item::{IsFnParam, AllowVis};
+use crate::parser::item::{AllowVis, IsFnParam};
 use crate::{
     bin_op_from_assign_op, errors,
     parser::{item::RequireTy, AllowOmitParens, Parser, RequireSigTy},
@@ -121,14 +121,10 @@ impl<'a> Parser<'a> {
                 }
             }
             TokenKind::OpenParen => {
-                if self.is(TokenKind::CloseParen) {
-                    Expr::UnitLit { span: tok.span.merge(self.last_span()) }
-                } else {
-                    let expr = self.parse_expr()?;
-                    let close = self.eat(TokenKind::CloseParen)?;
-                    let span = expr.span().merge(close.span);
-                    Expr::Group { expr: Box::new(expr), span }
-                }
+                let expr = self.parse_expr()?;
+                let close = self.eat(TokenKind::CloseParen)?;
+                let span = expr.span().merge(close.span);
+                Expr::Group { expr: Box::new(expr), span }
             }
             TokenKind::OpenCurly => {
                 self.back();

--- a/compiler_parse/src/parser/item.rs
+++ b/compiler_parse/src/parser/item.rs
@@ -147,7 +147,11 @@ impl<'a> Parser<'a> {
                 self.parse_fn_params(require_sig_ty)?
             };
 
-        let ret = if self.is(TokenKind::Arrow) { Some(self.parse_ty()?) } else { None };
+        let ret = if require_sig_ty == RequireSigTy::Yes || self.is_ty_start() {
+            Some(self.parse_ty()?)
+        } else {
+            None
+        };
 
         Ok((params, ret, is_c_variadic))
     }

--- a/compiler_parse/src/parser/pmatch.rs
+++ b/compiler_parse/src/parser/pmatch.rs
@@ -78,9 +78,9 @@ impl<'a> Parser<'a> {
         } else if let Some(mutability) = self.parse_optional_mutability() {
             let word = self.eat_ident()?.word();
             Ok(MatchPat::Name(word, mutability))
-        } else if self.is(TokenKind::OpenParen) {
+        } else if self.is(TokenKind::OpenCurly) {
             let start_span = self.last_span();
-            let last_span = self.eat(TokenKind::CloseParen)?.span;
+            let last_span = self.eat(TokenKind::CloseCurly)?.span;
             Ok(MatchPat::Unit(start_span.merge(last_span)))
         } else if self.is(TokenKind::Minus) {
             let start_span = self.last_span();

--- a/compiler_parse/src/parser/tyexpr.rs
+++ b/compiler_parse/src/parser/tyexpr.rs
@@ -48,6 +48,21 @@ impl<'a> Parser<'a> {
         Ok(ty)
     }
 
+    pub(super) fn is_ty_start(&self) -> bool {
+        // These pattern must stay in sync with `parse_ty`
+        matches!(
+            self.token().map(|t| t.kind),
+            Some(
+                TokenKind::Ident(..)
+                    | TokenKind::Amp
+                    | TokenKind::OpenBrack
+                    | TokenKind::Kw(Kw::Fn)
+                    | TokenKind::OpenParen
+                    | TokenKind::Underscore,
+            )
+        )
+    }
+
     fn parse_ty_path(&mut self, word: Word) -> DiagnosticResult<TyExpr> {
         let start_span = word.span();
         let mut path = vec![word];
@@ -71,7 +86,7 @@ impl<'a> Parser<'a> {
             (false, CallConv::default())
         };
         let (params, is_c_variadic) = self.parse_fn_tparams()?;
-        let ret = if self.is(TokenKind::Arrow) { Some(Box::new(self.parse_ty()?)) } else { None };
+        let ret = Box::new(self.parse_ty()?);
 
         Ok(TyExprFn {
             params,

--- a/compiler_parse/src/parser/tyexpr.rs
+++ b/compiler_parse/src/parser/tyexpr.rs
@@ -36,13 +36,10 @@ impl<'a> Parser<'a> {
                 TyExpr::Fn(fty)
             }
             TokenKind::OpenParen => {
-                if self.is(TokenKind::CloseParen) {
-                    TyExpr::Unit(tok.span.merge(self.last_span()))
-                } else {
-                    let ty = self.parse_ty()?;
-                    self.eat(TokenKind::CloseParen)?;
-                    ty
-                }
+                let ty = self.parse_ty()?;
+                let close = self.eat(TokenKind::CloseParen)?;
+                let span = ty.span().merge(close.span);
+                TyExpr::Group(Box::new(ty), span)
             }
             TokenKind::Underscore => TyExpr::Hole(tok.span),
             _ => return Err(errors::unexpected_token_err("a type", tok.kind, tok.span)),

--- a/compiler_parse/src/parser/tyexpr.rs
+++ b/compiler_parse/src/parser/tyexpr.rs
@@ -15,7 +15,7 @@ use crate::{
 
 impl<'a> Parser<'a> {
     pub(super) fn parse_ty(&mut self) -> DiagnosticResult<TyExpr> {
-        let tok = self.eat_any()?;
+        let tok = self.eat_any("a type")?;
 
         let ty = match tok.kind {
             TokenKind::Ident(..) => self.parse_ty_path(tok.word())?,

--- a/compiler_typeck/src/builtins.rs
+++ b/compiler_typeck/src/builtins.rs
@@ -26,6 +26,7 @@ pub(crate) fn define_all(cx: &mut Typeck) {
         (sym::ty::STR, cx.db.types.str),
         (sym::ty::CHAR, cx.db.types.char),
         (sym::ty::BOOL, cx.db.types.bool),
+        (sym::ty::UNIT, cx.db.types.unit),
         (sym::ty::NEVER, cx.db.types.never),
     ];
 

--- a/compiler_typeck/src/exprs.rs
+++ b/compiler_typeck/src/exprs.rs
@@ -507,9 +507,6 @@ pub(crate) fn check_expr(
             };
             Ok(cx.expr(hir::ExprKind::CharLit(*value), ty, *span))
         }
-        ast::Expr::UnitLit { span } => {
-            Ok(cx.expr(hir::ExprKind::Block(hir::Block { exprs: vec![] }), cx.db.types.unit, *span))
-        }
     }
 }
 

--- a/compiler_typeck/src/tyexpr.rs
+++ b/compiler_typeck/src/tyexpr.rs
@@ -84,7 +84,6 @@ pub(crate) fn check(
         TyExpr::Path(path, targs, span) => {
             check_path(cx, env, path, targs.as_deref(), *span, allow_hole)
         }
-        TyExpr::Unit(_) => Ok(cx.db.types.unit),
         TyExpr::Hole(span) => {
             if allow_hole == AllowTyHole::Yes {
                 Ok(cx.fresh_ty_var())
@@ -93,6 +92,7 @@ pub(crate) fn check(
                     .with_label(Label::primary(*span, "invalid type hole")))
             }
         }
+        TyExpr::Group(ty, _) => check(cx, env, ty, allow_hole),
     }
 }
 

--- a/compiler_typeck/src/tyexpr.rs
+++ b/compiler_typeck/src/tyexpr.rs
@@ -30,13 +30,7 @@ pub(crate) fn check(
                 params.push(ty);
             }
 
-            let ret = fn_ty
-                .ret
-                .as_ref()
-                .map(|ret| check(cx, env, ret, allow_hole))
-                .transpose()?
-                .unwrap_or(cx.db.types.unit);
-
+            let ret = check(cx, env, &fn_ty.ret, allow_hole)?;
             let mut flags = FnTyFlags::empty();
 
             if fn_ty.is_extern {

--- a/examples/binary-search.jin
+++ b/examples/binary-search.jin
@@ -1,4 +1,4 @@
-fn main() = {
+fn main() unit = {
     let slice = [1, 3, 42, 487, 5, 66, 4055, 33]
     match slice.binary-search(4055) {
         Option.Some(idx) -> println("found: {idx}")
@@ -6,7 +6,7 @@ fn main() = {
     }
 }
 
-fn binary-search(haystack: &[]int, needle: int) -> Option[uint] = {
+fn binary-search(haystack: &[]int, needle: int) Option[uint] = {
     let mut lower = 0
     let mut upper = haystack.len - 1
 

--- a/examples/bubble-sort.jin
+++ b/examples/bubble-sort.jin
@@ -1,4 +1,4 @@
-fn main() = {
+fn main() unit = {
     let mut slice = [1, 3, 42, 487, 5, 66, 4055, 33]
     print("Before: ")
     slice.print()
@@ -7,7 +7,7 @@ fn main() = {
     slice.print()
 }
 
-fn bubble-sort(slice: &mut []int) = {
+fn bubble-sort(slice: &mut []int) unit = {
     let mut n = slice.len
     let mut swapped = true
 
@@ -28,7 +28,7 @@ fn bubble-sort(slice: &mut []int) = {
     }
 }
 
-fn print(slice: &[]int) = {
+fn print(slice: &[]int) unit = {
     let mut i = 0
     for if i < slice.len {
         print("{slice.[i]} ")

--- a/examples/fs.jin
+++ b/examples/fs.jin
@@ -6,7 +6,7 @@ fn main() = {
         Result.Ok(contents) -> {
             print("--- Read ---\n{contents}")
             match std.fs.write("examples/file2.txt", contents) {
-                Result.Ok(()) -> {}
+                Result.Ok({}) -> {}
                 Result.Err(err) -> println("Error writing to 'examples/file2.txt': {err}")
             }
         }

--- a/examples/fs.jin
+++ b/examples/fs.jin
@@ -6,7 +6,7 @@ fn main() = {
         Result.Ok(contents) -> {
             print("--- Read ---\n{contents}")
             match std.fs.write("examples/file2.txt", contents) {
-                Result.Ok(()) -> ()
+                Result.Ok(()) -> {}
                 Result.Err(err) -> println("Error writing to 'examples/file2.txt': {err}")
             }
         }

--- a/examples/fs.jin
+++ b/examples/fs.jin
@@ -1,7 +1,7 @@
 use std.(fs, io)
 
 // TODO: Some sugar like unwrap and try syntax for `Result` would be nice here
-fn main() = {
+fn main() unit = {
     match std.fs.read-to-str("examples/file.txt") {
         Result.Ok(contents) -> {
             print("--- Read ---\n{contents}")

--- a/examples/linked-list.jin
+++ b/examples/linked-list.jin
@@ -3,7 +3,7 @@ type LinkedList[T](
     head: Option[Node[T]],
 )
 
-fn LinkedList.new[T]() -> LinkedList[T] = LinkedList(tail: Option.None, head: Option.None)
+fn LinkedList.new[T]() LinkedList[T] = LinkedList(tail: Option.None, head: Option.None)
 
 type Node[T](
     prev: Option[&mut Node[T]],
@@ -11,9 +11,9 @@ type Node[T](
     next: Option[Node[T]],
 )
 
-fn Node.new[T](data: T) -> Node[T] = Node(prev: Option.None, data: data, next: Option.None)
+fn Node.new[T](data: T) Node[T] = Node(prev: Option.None, data: data, next: Option.None)
 
-fn push-front[T](list: &mut LinkedList[T], data: T) = {
+fn push-front[T](list: &mut LinkedList[T], data: T) unit = {
     let mut node = Node.new(data)
     let node-mut = &mut node
 
@@ -26,7 +26,7 @@ fn push-front[T](list: &mut LinkedList[T], data: T) = {
     }
 }
 
-fn print(list: &LinkedList[int]) = {
+fn print(list: &LinkedList[int]) unit = {
     let mut curr = &list.head
 
     print("[")
@@ -47,7 +47,7 @@ fn print(list: &LinkedList[int]) = {
     println("]")
 }
 
-fn main() = {
+fn main() unit = {
     let mut list = LinkedList.new()
     list.push-front(3)
     list.push-front(2)

--- a/examples/quick-sort.jin
+++ b/examples/quick-sort.jin
@@ -1,4 +1,4 @@
-fn main() = {
+fn main() unit = {
     let mut slice = [1, 3, 42, 487, 5, 66, 4055, 33]
     print("Before: ")
     slice.print()
@@ -7,7 +7,7 @@ fn main() = {
     slice.print()
 }
 
-fn quick-sort(slice: &mut []int) = {
+fn quick-sort(slice: &mut []int) unit = {
     let len = slice.len
 
     if len < 2 {
@@ -19,7 +19,7 @@ fn quick-sort(slice: &mut []int) = {
     quick-sort(&mut slice.[pivot-idx + 1..len])
 }
 
-fn partition(slice: &mut []int) -> uint = {
+fn partition(slice: &mut []int) uint = {
     let len = slice.len
     let pivot-idx = len / 2
     let last-idx = len - 1
@@ -41,7 +41,7 @@ fn partition(slice: &mut []int) -> uint = {
     store-idx
 }
 
-fn print(slice: &[]int) = {
+fn print(slice: &[]int) unit = {
     let mut i = 0
     for if i < slice.len {
         print("{slice.[i]} ")

--- a/std/bool.jin
+++ b/std/bool.jin
@@ -1,6 +1,6 @@
 use std.str.StrBuf
 
-fn fmt*(b: &bool, buf: &mut StrBuf) =
+fn fmt*(b: &bool, buf: &mut StrBuf) unit =
     buf.push(if b { "true" } else { "false "})
 
-fn to-str*(b: bool) -> str = "{b}"
+fn to-str*(b: bool) str = "{b}"

--- a/std/builtin.jin
+++ b/std/builtin.jin
@@ -1,11 +1,11 @@
 @builtin("forget")
-fn extern "jin" forget*[T](x: &T)
+fn extern "jin" forget*[T](x: &T) unit
 
 @builtin("panic")
-fn extern "jin" panic*(msg: &str) -> never
+fn extern "jin" panic*(msg: &str) never
 
 @builtin("slice-grow")
-fn extern "jin" slice-grow*[T](slice: &mut []T, new-cap: uint)
+fn extern "jin" slice-grow*[T](slice: &mut []T, new-cap: uint) unit
 
 @builtin("slice-utf8-validate")
-fn extern "jin" slice-utf8-validate*(slice: &[]u8) -> bool
+fn extern "jin" slice-utf8-validate*(slice: &[]u8) bool

--- a/std/c.jin
+++ b/std/c.jin
@@ -18,13 +18,13 @@ type c-ssize-t* = int
 
 type mode-t* = u32
 
-fn extern "c" close*(fd: c-int) -> c-int
-fn extern "c" open*(pathname: ptr[c-char], flags: c-int, mode: mode-t) -> c-int
-fn extern "c" printf*(format: ptr[c-uchar], ..) -> c-int
-fn extern "c" read*(fd: c-int, buf: ptr[c-uchar], count: c-size-t) -> c-ssize-t
-fn extern "c" unlink*(pathname: ptr[c-char]) -> c-int
-fn extern "c" write*(fd: c-int, buf: ptr[c-uchar], count: c-size-t) -> c-ssize-t
-fn extern "c" __errno_location*() -> ptr[c-int]
+fn extern "c" close*(fd: c-int) c-int
+fn extern "c" open*(pathname: ptr[c-char], flags: c-int, mode: mode-t) c-int
+fn extern "c" printf*(format: ptr[c-uchar], ..) c-int
+fn extern "c" read*(fd: c-int, buf: ptr[c-uchar], count: c-size-t) c-ssize-t
+fn extern "c" unlink*(pathname: ptr[c-char]) c-int
+fn extern "c" write*(fd: c-int, buf: ptr[c-uchar], count: c-size-t) c-ssize-t
+fn extern "c" __errno_location*() ptr[c-int]
 
 const O_RDONLY*: c-int = 0
 const O_WRONLY*: c-int = 1

--- a/std/char.jin
+++ b/std/char.jin
@@ -5,7 +5,7 @@ use std.(
     str.(?),
 )
 
-fn char.from-digit*(num: u32, radix: u32) -> Option[char] = {
+fn char.from-digit*(num: u32, radix: u32) Option[char] = {
     assert(radix <= 36, "radix is too high (maximum 36)")
 
     if num < radix {
@@ -29,9 +29,9 @@ const MAX-ONE-B: u32 = 0x80;
 const MAX-TWO-B: u32 = 0x800;
 const MAX-THREE-B: u32 = 0x10000;
 
-fn len-utf8*(ch: char) -> uint = len-utf8(u32(ch))
+fn len-utf8*(ch: char) uint = len-utf8(u32(ch))
 
-fn len-utf8(code: u32) -> uint =
+fn len-utf8(code: u32) uint =
     if code < MAX-ONE-B {
         1
     } else if code < MAX-TWO-B {
@@ -42,10 +42,10 @@ fn len-utf8(code: u32) -> uint =
         4
     }
 
-fn encode-utf8*(ch: char, dst: &mut []u8) -> &mut []u8 =
+fn encode-utf8*(ch: char, dst: &mut []u8) &mut []u8 =
     encode-utf8-raw(u32(ch), dst)
 
-fn encode-utf8-raw*(code: u32, dst: &mut []u8) -> &mut []u8 = {
+fn encode-utf8-raw*(code: u32, dst: &mut []u8) &mut []u8 = {
     let len = code.len-utf8()
     assert(dst.len >= len)
 

--- a/std/collections/array.jin
+++ b/std/collections/array.jin
@@ -5,9 +5,9 @@ const MIN-CAP: uint = 4
 
 type Array*[T](buf: []T)
 
-fn Array.new*[T]() -> Array[T] = Array([])
+fn Array.new*[T]() Array[T] = Array([])
 
-fn Array.new*[T](len: uint, f: fn(uint) -> T) -> Array[T] = {
+fn Array.new*[T](len: uint, f: fn(uint) T) Array[T] = {
     let mut array = Array.with-cap(len)
     let mut i = 0
 
@@ -19,23 +19,23 @@ fn Array.new*[T](len: uint, f: fn(uint) -> T) -> Array[T] = {
     array
 }
 
-fn Array.from*[T](slice: []T) -> Array[T] = Array(slice)
+fn Array.from*[T](slice: []T) Array[T] = Array(slice)
 
-fn Array.with-cap*[T](cap: uint) -> Array[T] = {
+fn Array.with-cap*[T](cap: uint) Array[T] = {
     // TODO: use a polymorphic `std.cmp.max` function for this
     let c = if cap > MIN-CAP { cap } else { MIN-CAP }
     Array([:c])
 }
 
-fn len*[T](array: &Array[T]) -> uint = array.buf.len
-fn cap*[T](array: &Array[T]) -> uint = array.buf.cap
-fn is-empty*[T](array: &Array[T]) -> bool = array.len() == 0
+fn len*[T](array: &Array[T]) uint = array.buf.len
+fn cap*[T](array: &Array[T]) uint = array.buf.cap
+fn is-empty*[T](array: &Array[T]) bool = array.len() == 0
 
-fn as-ref*[T](array: &Array[T]) -> &[]T = &array.buf
-fn as-mut*[T](array: &mut Array[T]) -> &mut []T = &mut array.buf
-fn take*[T](array: Array[T]) -> []T = array.buf
+fn as-ref*[T](array: &Array[T]) &[]T = &array.buf
+fn as-mut*[T](array: &mut Array[T]) &mut []T = &mut array.buf
+fn take*[T](array: Array[T]) []T = array.buf
 
-fn get*[T](array: &Array[T], index: uint) -> Option[&T] = {
+fn get*[T](array: &Array[T], index: uint) Option[&T] = {
     if index < array.buf.len {
         Option.Some(&array.buf.[index])
     } else {
@@ -43,7 +43,7 @@ fn get*[T](array: &Array[T], index: uint) -> Option[&T] = {
     }
 }
 
-fn set*[T](array: &mut Array[T], index: uint, value: T) -> Option[T] = {
+fn set*[T](array: &mut Array[T], index: uint, value: T) Option[T] = {
     if index < array.buf.len {
         Option.Some(array.buf.[index] := value)
     } else {
@@ -51,12 +51,12 @@ fn set*[T](array: &mut Array[T], index: uint, value: T) -> Option[T] = {
     }
 }
 
-fn push*[T](array: &mut Array[T], value: T) = {
+fn push*[T](array: &mut Array[T], value: T) unit = {
     array.reserve(1)
     array.push-unchecked(value)
 }
 
-fn pop*[T](array: &mut Array[T]) -> Option[T] = {
+fn pop*[T](array: &mut Array[T]) Option[T] = {
     if array.buf.len == 0 {
         return Option.None
     }
@@ -65,33 +65,33 @@ fn pop*[T](array: &mut Array[T]) -> Option[T] = {
     Option.Some(unsafe (array.buf.ptr + array.buf.len).0)
 }
 
-fn clear*[T](array: &mut Array[T]) = {
+fn clear*[T](array: &mut Array[T]) unit = {
     array.buf = []
 }
 
-fn reserve*[T](array: &mut Array[T], additional: uint) = {
+fn reserve*[T](array: &mut Array[T], additional: uint) unit = {
     if array.needs-to-grow(additional) {
         array.grow(additional)
     }
 }
 
 // TODO: this should be marked `unsafe`
-fn push-unchecked*[T](array: &mut Array[T], value: T) = {
+fn push-unchecked*[T](array: &mut Array[T], value: T) unit = {
     unsafe array.buf.len += 1
     array.buf.[array.buf.len - 1] = value
 }
 
 // TODO: this should be marked `unsafe`
-fn set-len*[T](array: &mut Array[T], len: uint) = {
+fn set-len*[T](array: &mut Array[T], len: uint) unit = {
     unsafe array.buf.len = len
 }
 
-fn needs-to-grow[T](array: &Array[T], additional: uint) -> bool =
+fn needs-to-grow[T](array: &Array[T], additional: uint) bool =
     // TODO: this is prone to overflow, we should implement checked arithmetic
     array.buf.len + additional > array.buf.cap
 
 
-fn grow[T](array: &mut Array[T], additional: uint) = {
+fn grow[T](array: &mut Array[T], additional: uint) unit = {
     let cap = array.buf.cap
     if cap > 0 {
         let new-cap = max(cap * 2, cap + additional)
@@ -102,5 +102,5 @@ fn grow[T](array: &mut Array[T], additional: uint) = {
 }
 
 // TODO: use a polymorphic `std.cmp.max` function instead
-fn max(a: uint, b: uint) -> uint =
+fn max(a: uint, b: uint) uint =
     if a > b { a } else { b }

--- a/std/fs.jin
+++ b/std/fs.jin
@@ -96,7 +96,7 @@ fn read-to-str*(file: &File) -> io.Result[str] =
     match file.read-to-end() {
         Result.Ok(buf) -> match str.from-utf8(buf.take()) {
             Result.Ok(s) -> Result.Ok(s)
-            Result.Err(()) -> Result.Err(io.Error.InvalidData("stream did not contain valid UTF-8"))
+            Result.Err({}) -> Result.Err(io.Error.InvalidData("stream did not contain valid UTF-8"))
         }
         Result.Err(err) -> Result.Err(err)
     }

--- a/std/fs.jin
+++ b/std/fs.jin
@@ -116,7 +116,7 @@ fn write*(file: &mut File, buf: &[]u8) -> io.Result[uint] =
 fn remove-file*(path: &str) -> io.Result[unit] =
     match unsafe c.unlink(as[_](path.ptr)) {
         -1 -> Result.Err(io.Error.last-os-error())
-        _ -> Result.Ok(())
+        _ -> Result.Ok({})
     }
 
 fn `=drop`*(file: &mut File) =

--- a/std/fs.jin
+++ b/std/fs.jin
@@ -1,58 +1,58 @@
 use std.(c, io)
 
-fn read*(path: str) -> io.Result[Array[u8]] =
+fn read*(path: str) io.Result[Array[u8]] =
     read(&path)
 
-fn read*(path: &str) -> io.Result[Array[u8]] =
+fn read*(path: &str) io.Result[Array[u8]] =
     match File.open(path) {
         Result.Ok(file) -> file.read-to-end()
         Result.Err(err) -> Result.Err(err)
     }
 
-fn read-to-str*(path: str) -> io.Result[str] =
+fn read-to-str*(path: str) io.Result[str] =
     read-to-str(&path)
 
-fn read-to-str*(path: &str) -> io.Result[str] =
+fn read-to-str*(path: &str) io.Result[str] =
     match File.open(path) {
         Result.Ok(file) -> file.read-to-str()
         Result.Err(err) -> Result.Err(err)
     }
 
-fn write*(path: str, contents: str) -> io.Result[unit] =
+fn write*(path: str, contents: str) io.Result[unit] =
     write(&path, &contents)
 
-fn write*(path: &str, contents: str) -> io.Result[unit] =
+fn write*(path: &str, contents: str) io.Result[unit] =
     write(path, &contents)
 
-fn write*(path: str, contents: &str) -> io.Result[unit] =
+fn write*(path: str, contents: &str) io.Result[unit] =
     write(&path, contents.as-bytes())
 
-fn write*(path: &str, contents: &str) -> io.Result[unit] =
+fn write*(path: &str, contents: &str) io.Result[unit] =
     write(path, contents.as-bytes())
 
-fn write*(path: str, bytes: &[]u8) -> io.Result[unit] =
+fn write*(path: str, bytes: &[]u8) io.Result[unit] =
     write(&path, bytes)
 
-fn write*(path: &str, bytes: &[]u8) -> io.Result[unit] =
+fn write*(path: &str, bytes: &[]u8) io.Result[unit] =
     match File.create(path) {
         Result.Ok(mut file) -> file.write(bytes).map fn(_) {}
         Result.Err(err) -> Result.Err(err)
     }
 
 // TODO: Add an API for custom file opening with `OpenOptions`
-fn File.open*(path: &str) -> io.Result[File] =
+fn File.open*(path: &str) io.Result[File] =
     match open-impl(path, c.O_RDONLY, 0) {
         -1 -> Result.Err(io.Error.last-os-error())
         fd -> Result.Ok(File(fd))
     }
 
-fn File.create*(path: &str) -> io.Result[File] =
+fn File.create*(path: &str) io.Result[File] =
     match open-impl(path, c.O_WRONLY | c.O_CREAT | c.O_TRUNC, 0o644) {
         -1 -> Result.Err(io.Error.last-os-error())
         fd -> Result.Ok(File(fd))
     }
 
-fn open-impl(path: &str, flags: c.c-int, mode: c.mode-t) -> c.c-int = {
+fn open-impl(path: &str, flags: c.c-int, mode: c.mode-t) c.c-int = {
     let pathname = unsafe as[_](path.as-bytes().ptr)
     // TODO: cross-platform open
     unsafe c.open(pathname, flags, mode)
@@ -63,7 +63,7 @@ type File*(fd: RawFd)
 
 const DEFAULT-BUF-SIZE: uint = 8 * 1024
 
-fn read-to-end*(file: &File) -> io.Result[Array[u8]] = {
+fn read-to-end*(file: &File) io.Result[Array[u8]] = {
     // TODO: initialize with-cap to file's size (or 0 if reading size fails)
     // TODO: implement `Array.filled(T, uint) where T: Copy`
     let mut buf = Array.new[u8]()
@@ -92,7 +92,7 @@ fn read-to-end*(file: &File) -> io.Result[Array[u8]] = {
     Result.Ok(buf)
 }
 
-fn read-to-str*(file: &File) -> io.Result[str] =
+fn read-to-str*(file: &File) io.Result[str] =
     match file.read-to-end() {
         Result.Ok(buf) -> match str.from-utf8(buf.take()) {
             Result.Ok(s) -> Result.Ok(s)
@@ -101,23 +101,23 @@ fn read-to-str*(file: &File) -> io.Result[str] =
         Result.Err(err) -> Result.Err(err)
     }
 
-fn read*(file: &File, buf: &mut []u8) -> io.Result[uint] =
+fn read*(file: &File, buf: &mut []u8) io.Result[uint] =
     match unsafe c.read(file.fd, buf.ptr, buf.len) {
         -1 -> Result.Err(io.Error.last-os-error())
         len -> Result.Ok(uint(len))
     }
 
-fn write*(file: &mut File, buf: &[]u8) -> io.Result[uint] =
+fn write*(file: &mut File, buf: &[]u8) io.Result[uint] =
     match unsafe c.write(file.fd, buf.ptr, buf.len) {
         -1 -> Result.Err(io.Error.last-os-error())
         written -> Result.Ok(uint(written))
     }
 
-fn remove-file*(path: &str) -> io.Result[unit] =
+fn remove-file*(path: &str) io.Result[unit] =
     match unsafe c.unlink(as[_](path.ptr)) {
         -1 -> Result.Err(io.Error.last-os-error())
         _ -> Result.Ok({})
     }
 
-fn `=drop`*(file: &mut File) =
+fn `=drop`*(file: &mut File) unit =
     unsafe c.close(file.fd)

--- a/std/fs.jin
+++ b/std/fs.jin
@@ -18,22 +18,22 @@ fn read-to-str*(path: &str) -> io.Result[str] =
         Result.Err(err) -> Result.Err(err)
     }
 
-fn write*(path: str, contents: str) -> io.Result[()] =
+fn write*(path: str, contents: str) -> io.Result[unit] =
     write(&path, &contents)
 
-fn write*(path: &str, contents: str) -> io.Result[()] =
+fn write*(path: &str, contents: str) -> io.Result[unit] =
     write(path, &contents)
 
-fn write*(path: str, contents: &str) -> io.Result[()] =
+fn write*(path: str, contents: &str) -> io.Result[unit] =
     write(&path, contents.as-bytes())
 
-fn write*(path: &str, contents: &str) -> io.Result[()] =
+fn write*(path: &str, contents: &str) -> io.Result[unit] =
     write(path, contents.as-bytes())
 
-fn write*(path: str, bytes: &[]u8) -> io.Result[()] =
+fn write*(path: str, bytes: &[]u8) -> io.Result[unit] =
     write(&path, bytes)
 
-fn write*(path: &str, bytes: &[]u8) -> io.Result[()] =
+fn write*(path: &str, bytes: &[]u8) -> io.Result[unit] =
     match File.create(path) {
         Result.Ok(mut file) -> file.write(bytes).map fn(_) {}
         Result.Err(err) -> Result.Err(err)
@@ -113,7 +113,7 @@ fn write*(file: &mut File, buf: &[]u8) -> io.Result[uint] =
         written -> Result.Ok(uint(written))
     }
 
-fn remove-file*(path: &str) -> io.Result[()] =
+fn remove-file*(path: &str) -> io.Result[unit] =
     match unsafe c.unlink(as[_](path.ptr)) {
         -1 -> Result.Err(io.Error.last-os-error())
         _ -> Result.Ok(())

--- a/std/int.jin
+++ b/std/int.jin
@@ -34,51 +34,51 @@ const U64-MAX*: u64 = 18_446_744_073_709_551_615
 const UINT-MIN*: uint = U64-MIN
 const UINT-MAX*: uint = U64-MAX
 
-fn abs*(x: i8) -> i8 = if x > 0 { x } else { -x }
-fn abs*(x: i16) -> i16 = if x > 0 { x } else { -x }
-fn abs*(x: i32) -> i32 = if x > 0 { x } else { -x }
-fn abs*(x: i64) -> i64 = if x > 0 { x } else { -x }
-fn abs*(x: int) -> int = if x > 0 { x } else { -x }
+fn abs*(x: i8) i8 = if x > 0 { x } else { -x }
+fn abs*(x: i16) i16 = if x > 0 { x } else { -x }
+fn abs*(x: i32) i32 = if x > 0 { x } else { -x }
+fn abs*(x: i64) i64 = if x > 0 { x } else { -x }
+fn abs*(x: int) int = if x > 0 { x } else { -x }
 
-fn to-str*(x: i8) -> str = fmt-impl(uint(x.abs()), x < 0, Format.Decimal)
-fn to-str*(x: i8, format: Format) -> str = fmt-impl(uint(x.abs()), x < 0, format)
-fn fmt*(x: &i8, buf: &mut StrBuf) = buf.push(x.to-str(Format.Decimal))
+fn to-str*(x: i8) str = fmt-impl(uint(x.abs()), x < 0, Format.Decimal)
+fn to-str*(x: i8, format: Format) str = fmt-impl(uint(x.abs()), x < 0, format)
+fn fmt*(x: &i8, buf: &mut StrBuf) unit = buf.push(x.to-str(Format.Decimal))
 
-fn to-str*(x: i16) -> str = fmt-impl(uint(x.abs()), x < 0, Format.Decimal)
-fn to-str*(x: i16, format: Format) -> str = fmt-impl(uint(x.abs()), x < 0, format)
-fn fmt*(x: &i16, buf: &mut StrBuf) = buf.push(x.to-str(Format.Decimal))
+fn to-str*(x: i16) str = fmt-impl(uint(x.abs()), x < 0, Format.Decimal)
+fn to-str*(x: i16, format: Format) str = fmt-impl(uint(x.abs()), x < 0, format)
+fn fmt*(x: &i16, buf: &mut StrBuf) unit = buf.push(x.to-str(Format.Decimal))
 
-fn to-str*(x: i32) -> str = fmt-impl(uint(x.abs()), x < 0, Format.Decimal)
-fn to-str*(x: i32, format: Format) -> str = fmt-impl(uint(x.abs()), x < 0, format)
-fn fmt*(x: &i32, buf: &mut StrBuf) = buf.push(x.to-str(Format.Decimal))
+fn to-str*(x: i32) str = fmt-impl(uint(x.abs()), x < 0, Format.Decimal)
+fn to-str*(x: i32, format: Format) str = fmt-impl(uint(x.abs()), x < 0, format)
+fn fmt*(x: &i32, buf: &mut StrBuf) unit = buf.push(x.to-str(Format.Decimal))
 
-fn to-str*(x: i64) -> str = fmt-impl(uint(x.abs()), x < 0, Format.Decimal)
-fn to-str*(x: i64, format: Format) -> str = fmt-impl(uint(x.abs()), x < 0, format)
-fn fmt*(x: &i64, buf: &mut StrBuf) = buf.push(x.to-str(Format.Decimal))
+fn to-str*(x: i64) str = fmt-impl(uint(x.abs()), x < 0, Format.Decimal)
+fn to-str*(x: i64, format: Format) str = fmt-impl(uint(x.abs()), x < 0, format)
+fn fmt*(x: &i64, buf: &mut StrBuf) unit = buf.push(x.to-str(Format.Decimal))
 
-fn to-str*(x: int) -> str = fmt-impl(uint(x.abs()), x < 0, Format.Decimal)
-fn to-str*(x: int, format: Format) -> str = fmt-impl(uint(x.abs()), x < 0, format)
-fn fmt*(x: &int, buf: &mut StrBuf) = buf.push(x.to-str(Format.Decimal))
+fn to-str*(x: int) str = fmt-impl(uint(x.abs()), x < 0, Format.Decimal)
+fn to-str*(x: int, format: Format) str = fmt-impl(uint(x.abs()), x < 0, format)
+fn fmt*(x: &int, buf: &mut StrBuf) unit = buf.push(x.to-str(Format.Decimal))
 
-fn to-str*(x: u8) -> str = fmt-impl(x, false, Format.Decimal)
-fn to-str*(x: u8, format: Format) -> str = fmt-impl(x, false, format)
-fn fmt*(x: &u8, buf: &mut StrBuf) = buf.push(x.to-str(Format.Decimal))
+fn to-str*(x: u8) str = fmt-impl(x, false, Format.Decimal)
+fn to-str*(x: u8, format: Format) str = fmt-impl(x, false, format)
+fn fmt*(x: &u8, buf: &mut StrBuf) unit = buf.push(x.to-str(Format.Decimal))
 
-fn to-str*(x: u16) -> str = fmt-impl(x, false, Format.Decimal)
-fn to-str*(x: u16, format: Format) -> str = fmt-impl(x, false, format)
-fn fmt*(x: &u16, buf: &mut StrBuf) = buf.push(x.to-str(Format.Decimal))
+fn to-str*(x: u16) str = fmt-impl(x, false, Format.Decimal)
+fn to-str*(x: u16, format: Format) str = fmt-impl(x, false, format)
+fn fmt*(x: &u16, buf: &mut StrBuf) unit = buf.push(x.to-str(Format.Decimal))
 
-fn to-str*(x: u32) -> str = fmt-impl(x, false, Format.Decimal)
-fn to-str*(x: u32, format: Format) -> str = fmt-impl(x, false, format)
-fn fmt*(x: &u32, buf: &mut StrBuf) = buf.push(x.to-str(Format.Decimal))
+fn to-str*(x: u32) str = fmt-impl(x, false, Format.Decimal)
+fn to-str*(x: u32, format: Format) str = fmt-impl(x, false, format)
+fn fmt*(x: &u32, buf: &mut StrBuf) unit = buf.push(x.to-str(Format.Decimal))
 
-fn to-str*(x: u64) -> str = fmt-impl(x, false, Format.Decimal)
-fn to-str*(x: u64, format: Format) -> str = fmt-impl(x, false, format)
-fn fmt*(x: &u64, buf: &mut StrBuf) = buf.push(x.to-str(Format.Decimal))
+fn to-str*(x: u64) str = fmt-impl(x, false, Format.Decimal)
+fn to-str*(x: u64, format: Format) str = fmt-impl(x, false, format)
+fn fmt*(x: &u64, buf: &mut StrBuf) unit = buf.push(x.to-str(Format.Decimal))
 
-fn to-str*(x: uint) -> str = fmt-impl(x, false, Format.Decimal)
-fn to-str*(x: uint, format: Format) -> str = fmt-impl(x, false, format)
-fn fmt*(x: &uint, buf: &mut StrBuf) = buf.push(x.to-str(Format.Decimal))
+fn to-str*(x: uint) str = fmt-impl(x, false, Format.Decimal)
+fn to-str*(x: uint, format: Format) str = fmt-impl(x, false, format)
+fn fmt*(x: &uint, buf: &mut StrBuf) unit = buf.push(x.to-str(Format.Decimal))
 
 type Format* {
     Binary
@@ -86,7 +86,7 @@ type Format* {
     Hex
 }
 
-fn base*(f: Format) -> uint = match f {
+fn base*(f: Format) uint = match f {
     Format.Binary -> 2
     Format.Decimal -> 10
     Format.Hex -> 16
@@ -94,7 +94,7 @@ fn base*(f: Format) -> uint = match f {
 
 // TODO: We can avoid this allocation if we add stack allocated arrays to the language,
 // and stack allocate an uninitialized [u8; 22] instead of using a StrBuf
-fn fmt-impl(mut num: uint, is-neg: bool, format: Format) -> str = {
+fn fmt-impl(mut num: uint, is-neg: bool, format: Format) str = {
     let base = format.base()
     let mut buf = StrBuf.with-cap(22)
 

--- a/std/io.jin
+++ b/std/io.jin
@@ -7,14 +7,14 @@ use std.(
 
 const STDOUT: i32 = 1
 
-fn print*(msg: &str) =
+fn print*(msg: &str) unit =
     unsafe write(STDOUT, as[_](msg.ptr), msg.len)
 
-fn print*(msg: str) = print(&msg)
+fn print*(msg: str) unit = print(&msg)
 
-fn println*() = print("\n")
-fn println*(msg: &str) = print("{msg}\n")
-fn println*(msg: str) = println(&msg)
+fn println*() unit = print("\n")
+fn println*(msg: &str) unit = print("{msg}\n")
+fn println*(msg: str) unit = println(&msg)
 
 type Result*[T] = std.result.Result[T, Error]
 
@@ -29,7 +29,7 @@ type Error* {
     Other(code: i32)
 }
 
-fn Error.from-os-error*(code: i32) -> Error =
+fn Error.from-os-error*(code: i32) Error =
     match code {
         errors.EPERM -> Error.PermissionDenied
         errors.ENOENT -> Error.NotFound
@@ -41,10 +41,10 @@ fn Error.from-os-error*(code: i32) -> Error =
     }
 
 // TODO: cross-platform errno
-fn Error.last-os-error*() -> Error =
+fn Error.last-os-error*() Error =
     Error.from-os-error(unsafe (c.__errno_location().0))
 
-fn fmt*(err: &Error, buf: &mut StrBuf) =
+fn fmt*(err: &Error, buf: &mut StrBuf) unit =
     match err {
         Error.PermissionDenied -> buf.push("Permission denied")
         Error.NotFound -> buf.push("Not found")

--- a/std/option.jin
+++ b/std/option.jin
@@ -5,28 +5,28 @@ type Option*[T] {
     None
 }
 
-fn or-panic*[T](opt: Option[T]) -> T =
+fn or-panic*[T](opt: Option[T]) T =
     match opt {
         Option.Some(v) -> v
         Option.None -> panic("called `or-panic` on a `None` value")
     }
 
-fn is-some*[T](opt: &Option[T]) -> bool =
+fn is-some*[T](opt: &Option[T]) bool =
     match opt {
         Option.Some(_) -> true
         Option.None -> false
     }
 
-fn is-none*[T](opt: &Option[T]) -> bool =
+fn is-none*[T](opt: &Option[T]) bool =
     !opt.is-some()
 
-fn map*[A, B](opt: Option[A], f: fn(A) -> B) -> Option[B] =
+fn map*[A, B](opt: Option[A], f: fn(A) B) Option[B] =
     match opt {
         Option.Some(v) -> Option.Some(f(v))
         Option.None -> Option.None
     }
 
-fn map-or*[A, B](opt: Option[A], default: B, f: fn(A) -> B) -> B =
+fn map-or*[A, B](opt: Option[A], default: B, f: fn(A) B) B =
     match opt {
         Option.Some(v) -> f(v)
         Option.None -> default

--- a/std/panicking.jin
+++ b/std/panicking.jin
@@ -1,17 +1,17 @@
 use std.builtin
 use std.str.(?)
 
-fn panic*() -> never = panic("explicit panic")
-fn panic*(msg: str) -> never = panic(&msg)
-fn panic*(msg: &str) -> never = unsafe builtin.panic(msg)
+fn panic*() never = panic("explicit panic")
+fn panic*(msg: str) never = panic(&msg)
+fn panic*(msg: &str) never = unsafe builtin.panic(msg)
 
-fn todo*() -> never = panic("not yet implemented")
-fn todo*(msg: str) -> never = todo(&msg)
-fn todo*(msg: &str) -> never = panic("not yet implemented: {msg}")
+fn todo*() never = panic("not yet implemented")
+fn todo*(msg: str) never = todo(&msg)
+fn todo*(msg: &str) never = panic("not yet implemented: {msg}")
 
-fn assert*(cond: bool) =
+fn assert*(cond: bool) unit =
     if !cond { panic("assertion failed") }
 
-fn assert*(cond: bool, msg: str) = assert(cond, &msg)
-fn assert*(cond: bool, msg: &str) =
+fn assert*(cond: bool, msg: str) unit = assert(cond, &msg)
+fn assert*(cond: bool, msg: &str) unit =
     if !cond { panic("assertion failed: {msg}") }

--- a/std/ptr.jin
+++ b/std/ptr.jin
@@ -1,2 +1,2 @@
-fn null*[T]() -> ptr[T] = unsafe as[_](0)
-fn is-null*[T](p: ptr[T]) -> bool = unsafe uint(p) == 0
+fn null*[T]() ptr[T] = unsafe as[_](0)
+fn is-null*[T](p: ptr[T]) bool = unsafe uint(p) == 0

--- a/std/result.jin
+++ b/std/result.jin
@@ -3,16 +3,16 @@ type Result*[T, E] {
     Err(error: E)
 }
 
-fn is-ok*[T, E](result: &Result[T, E]) -> bool =
+fn is-ok*[T, E](result: &Result[T, E]) bool =
     match result {
         Result.Ok(_) -> true
         Result.Err(_) -> false
     }
 
-fn is-err*[T, E](result: &Result[T, E]) -> bool =
+fn is-err*[T, E](result: &Result[T, E]) bool =
     !result.is-ok()
 
-fn map*[A, B, E](result: Result[A, E], f: fn(A) -> B) -> Result[B, E] =
+fn map*[A, B, E](result: Result[A, E], f: fn(A) B) Result[B, E] =
     match result {
         Result.Ok(v) -> Result.Ok(f(v))
         Result.Err(e) -> Result.Err(e)

--- a/std/slice.jin
+++ b/std/slice.jin
@@ -1,10 +1,10 @@
-fn swap*[T](s: &mut []T, a: uint, b: uint) = unsafe {
+fn swap*[T](s: &mut []T, a: uint, b: uint) unit = unsafe {
     let pa = s.ptr + a
     let pb = s.ptr + b
     pb.0 = pa.0 := pb.0
 }
 
-fn reverse*[T](s: &mut []T) = {
+fn reverse*[T](s: &mut []T) unit = {
     let mut i = 0
     let mut j = s.len - 1
 

--- a/std/str.jin
+++ b/std/str.jin
@@ -2,14 +2,14 @@ use std.builtin
 use std.char.(encode-utf8-raw, ?)
 use std.collections.Array
 
-fn str.from-utf8*(bytes: []u8) -> Result[str, ()] =
+fn str.from-utf8*(bytes: []u8) -> Result[str, unit] =
     if unsafe builtin.slice-utf8-validate(&bytes) {
         Result.Ok(unsafe as[_](bytes))
     } else {
         Result.Err(())
     }
 
-fn str.from-utf8*(bytes: &[]u8) -> Result[&str, ()] =
+fn str.from-utf8*(bytes: &[]u8) -> Result[&str, unit] =
     if unsafe builtin.slice-utf8-validate(bytes) {
         Result.Ok(unsafe as[_](bytes))
     } else {

--- a/std/str.jin
+++ b/std/str.jin
@@ -6,14 +6,14 @@ fn str.from-utf8*(bytes: []u8) -> Result[str, unit] =
     if unsafe builtin.slice-utf8-validate(&bytes) {
         Result.Ok(unsafe as[_](bytes))
     } else {
-        Result.Err(())
+        Result.Err({})
     }
 
 fn str.from-utf8*(bytes: &[]u8) -> Result[&str, unit] =
     if unsafe builtin.slice-utf8-validate(bytes) {
         Result.Ok(unsafe as[_](bytes))
     } else {
-        Result.Err(())
+        Result.Err({})
     }
 
 // TODO: should be marked unsafe

--- a/std/str.jin
+++ b/std/str.jin
@@ -2,14 +2,14 @@ use std.builtin
 use std.char.(encode-utf8-raw, ?)
 use std.collections.Array
 
-fn str.from-utf8*(bytes: []u8) -> Result[str, unit] =
+fn str.from-utf8*(bytes: []u8) Result[str, unit] =
     if unsafe builtin.slice-utf8-validate(&bytes) {
         Result.Ok(unsafe as[_](bytes))
     } else {
         Result.Err({})
     }
 
-fn str.from-utf8*(bytes: &[]u8) -> Result[&str, unit] =
+fn str.from-utf8*(bytes: &[]u8) Result[&str, unit] =
     if unsafe builtin.slice-utf8-validate(bytes) {
         Result.Ok(unsafe as[_](bytes))
     } else {
@@ -17,52 +17,52 @@ fn str.from-utf8*(bytes: &[]u8) -> Result[&str, unit] =
     }
 
 // TODO: should be marked unsafe
-fn str.from-utf8-unchecked*(bytes: []u8) -> str =
+fn str.from-utf8-unchecked*(bytes: []u8) str =
     unsafe as[_](bytes)
 
 // TODO: should be marked unsafe
-fn str.from-utf8-unchecked*(bytes: &[]u8) -> &str =
+fn str.from-utf8-unchecked*(bytes: &[]u8) &str =
     unsafe as[_](bytes)
 
 // TODO: should be marked unsafe
-fn str.from-utf8-mut-unchecked*(bytes: &mut []u8) -> &mut str =
+fn str.from-utf8-mut-unchecked*(bytes: &mut []u8) &mut str =
     unsafe as[_](bytes)
 
-fn as-bytes*(s: &str) -> &[]u8 = unsafe as[_](s)
-fn as-bytes-mut*(s: &mut str) -> &mut []u8 = unsafe as[_](s)
+fn as-bytes*(s: &str) &[]u8 = unsafe as[_](s)
+fn as-bytes-mut*(s: &mut str) &mut []u8 = unsafe as[_](s)
 
-fn fmt*(s: &str, buf: &mut StrBuf) = buf.push(s)
+fn fmt*(s: &str, buf: &mut StrBuf) unit = buf.push(s)
 
 type StrBuf*(array: Array[u8])
 
-fn StrBuf.new*() -> StrBuf = StrBuf.with-cap(1)
+fn StrBuf.new*() StrBuf = StrBuf.with-cap(1)
 
-fn StrBuf.with-cap*(cap: uint) -> StrBuf =
+fn StrBuf.with-cap*(cap: uint) StrBuf =
     StrBuf(array-with-nul-byte(cap))
 
-fn len*(sb: &StrBuf) -> uint = sb.array.len() - 1
-fn cap*(sb: &StrBuf) -> uint = sb.array.cap()
-fn is-empty*(sb: &StrBuf) -> bool = sb.len() == 0
+fn len*(sb: &StrBuf) uint = sb.array.len() - 1
+fn cap*(sb: &StrBuf) uint = sb.array.cap()
+fn is-empty*(sb: &StrBuf) bool = sb.len() == 0
 
-fn as-ref*(sb: &StrBuf) -> &str =
+fn as-ref*(sb: &StrBuf) &str =
     str.from-utf8-unchecked(
         &sb.array.as-ref().[..sb.array.len() - 1]
     )
 
-fn as-mut*(sb: &mut StrBuf) -> &mut str =
+fn as-mut*(sb: &mut StrBuf) &mut str =
     str.from-utf8-mut-unchecked(
         &mut sb.array.as-mut().[..sb.array.len() - 1]
     )
 
-fn take*(mut sb: StrBuf) -> str = {
+fn take*(mut sb: StrBuf) str = {
     let s = sb.array.take()
     unsafe s.len -= 1
     str.from-utf8-unchecked(s)
 }
 
-fn push*(sb: &mut StrBuf, s: str) = sb.push(&s)
+fn push*(sb: &mut StrBuf, s: str) unit = sb.push(&s)
 
-fn push*(sb: &mut StrBuf, s: &str) = {
+fn push*(sb: &mut StrBuf, s: &str) unit = {
     if s.len == 0 {
         return
     }
@@ -83,7 +83,7 @@ fn push*(sb: &mut StrBuf, s: &str) = {
     sb.array.push(b'\0')
 }
 
-fn push*(sb: &mut StrBuf, ch: char) = {
+fn push*(sb: &mut StrBuf, ch: char) unit = {
     let len = sb.array.len()
     let ch-len = ch.len-utf8()
     let new-len = len + ch-len
@@ -98,11 +98,11 @@ fn push*(sb: &mut StrBuf, ch: char) = {
     sb.array.push(b'\0')
 }
 
-fn clear*(sb: &mut StrBuf) = {
+fn clear*(sb: &mut StrBuf) unit = {
     sb.array = array-with-nul-byte(sb.array.cap())
 }
 
-fn array-with-nul-byte(cap: uint) -> Array[u8] = {
+fn array-with-nul-byte(cap: uint) Array[u8] = {
     let mut a = Array.with-cap(cap)
     a.push(b'\0')
     a

--- a/tests/anon-fn.jin
+++ b/tests/anon-fn.jin
@@ -1,7 +1,7 @@
-fn main() = {
+fn main() unit = {
     if Option.Some(1).map-or(false) fn(x) { x == 1 } {
-        call(fn { println("hello") })
+        call fn { println("hello") }
     }
 }
 
-fn call(f: fn()) = f()
+fn call(f: fn() unit) unit = f()

--- a/tests/array-test.jin
+++ b/tests/array-test.jin
@@ -1,6 +1,6 @@
-fn extern "c" printf(fmt: ptr[u8], ..) -> i32
+fn extern "c" printf(fmt: ptr[u8], ..) i32
 
-fn main() = {
+fn main() unit = {
     let mut array = Array.new[int]()
 
     println("Array push:")
@@ -38,18 +38,18 @@ fn main() = {
     array.print()
 }
 
-fn print-at(array: &Array[int], idx: uint) = {
+fn print-at(array: &Array[int], idx: uint) unit = {
     match array.get(idx) {
         Option.Some(x) -> unsafe printf("array[%d] = Some(%d)\n".ptr, idx, x)
         Option.None -> unsafe printf("array[%d] = None\n".ptr, idx)
     }
 }
 
-fn print(array: &Array[int]) = {
+fn print(array: &Array[int]) unit = {
     array.as-ref().print()
 }
 
-fn print(slice: &[]int) = {
+fn print(slice: &[]int) unit = {
     unsafe printf("[".ptr)
     let mut i = 0
     for if i < slice.len {

--- a/tests/associated-fns.jin
+++ b/tests/associated-fns.jin
@@ -1,14 +1,14 @@
-fn extern "c" printf(fmt: ptr[u8], ..) -> i32
+fn extern "c" printf(fmt: ptr[u8], ..) i32
 
-fn main() = {
+fn main() unit = {
     let box = Box.default()
     box.print()
 }
 
 type Box(value: int)
 
-fn Box.default() -> Box = Box(0)
+fn Box.default() Box = Box(0)
 
-fn print(box: &Box) = {
+fn print(box: &Box) unit = {
     unsafe printf("Box(%d)\n".ptr, box.value)
 }

--- a/tests/bitwise.jin
+++ b/tests/bitwise.jin
@@ -1,9 +1,9 @@
-fn extern "c" printf(fmt: ptr[u8], ..) -> i32
+fn extern "c" printf(fmt: ptr[u8], ..) i32
 
-fn a() -> u8 = 5
-fn b() -> u8 = 9
+fn a() u8 = 5
+fn b() u8 = 9
 
-fn main() = {
+fn main() unit = {
     // a = 5(00000101)
     let a: u8 = a()
     // b = 9(00001001)

--- a/tests/callbacks.jin
+++ b/tests/callbacks.jin
@@ -1,23 +1,23 @@
-fn main() = {
+fn main() unit = {
     run(print-answer)
     do-add(add, 1, 2)
     println("map: {map(1, int-to-uint)}")
 }
 
-fn run(f: fn()) = f()
+fn run(f: fn() unit) unit = f()
 
-fn print-answer() =
+fn print-answer() unit =
     println("The answer is {42}")
 
-fn add(a: int, b: int) -> int = {
+fn add(a: int, b: int) int = {
     a + b
 }
 
-fn do-add(f: fn(int, int) -> int, a: int, b: int) =
+fn do-add(f: fn(int, int) int, a: int, b: int) unit =
     println("a + b = {f(a, b)}")
 
-fn map[A, B](val: A, f: fn(A) -> B) -> B = {
+fn map[A, B](val: A, f: fn(A) B) B = {
     f(val)
 }
 
-fn int-to-uint(val: int) -> uint = uint(val)
+fn int-to-uint(val: int) uint = uint(val)

--- a/tests/destroy-poly.jin
+++ b/tests/destroy-poly.jin
@@ -1,4 +1,4 @@
-fn main() = {
+fn main() unit = {
 	let box = Box(Bag(Box(1), Box(Box(2))))
 	drop(box)
 }
@@ -6,4 +6,4 @@ fn main() = {
 type Box[T](v: T)
 type Bag(a: Box[int], b: Box[Box[int]])
 
-fn drop[T](value: T) = {}
+fn drop[T](value: T) unit = {}

--- a/tests/floats.jin
+++ b/tests/floats.jin
@@ -1,6 +1,6 @@
-fn extern "c" printf(fmt: ptr[u8], ..) -> i32
+fn extern "c" printf(fmt: ptr[u8], ..) i32
 
-fn main() = {
+fn main() unit = {
     let a = 2.0
     let b = 6.0
 

--- a/tests/fn-overloading.jin
+++ b/tests/fn-overloading.jin
@@ -2,9 +2,9 @@ mod child
 
 use fn-overloading.child.(*)
 
-fn extern "c" printf(fmt: ptr[u8], ..) -> i32
+fn extern "c" printf(fmt: ptr[u8], ..) i32
 
-fn main() = {
+fn main() unit = {
 	unsafe printf("Function overload matching:\n".ptr)
 	add(int(1), int(1)) // exact int
 	add(1, 1) // untyped int matching
@@ -41,22 +41,22 @@ fn main() = {
 	child.poly[int](1) // picking a module function with type application
 }
 
-fn add-one(x: int) -> int = {
+fn add-one(x: int) int = {
 	x + 1
 }
 
-fn named(~x: int) = {
+fn named(~x: int) unit = {
 	unsafe printf("named: x = %d\n".ptr, x)
 }
 
-fn named(~x: int, ~y: int) = {
+fn named(~x: int, ~y: int) unit = {
 	unsafe printf("named: x = %d, y = %d\n".ptr, x, y)
 }
 
-fn named(~z: int) = {
+fn named(~z: int) unit = {
 	unsafe printf("named: z = %d\n".ptr, z)
 }
 
-fn named[T](~x: T) = {
+fn named[T](~x: T) unit = {
 	unsafe printf("named[a]: x = %d\n".ptr, x)
 }

--- a/tests/fn-overloading/child.jin
+++ b/tests/fn-overloading/child.jin
@@ -1,25 +1,25 @@
-fn extern "c" printf(fmt: ptr[u8], ..) -> i32
+fn extern "c" printf(fmt: ptr[u8], ..) i32
 
-fn add*() = {
+fn add*() unit = {
 	println("there's nothing to add...\n")
 }
 
-fn add*(a: int, b: int) = {
+fn add*(a: int, b: int) unit = {
 	println("add ints: {a + b}")
 }
 
-fn add*(a: int, b: int, c: int) = {
+fn add*(a: int, b: int, c: int) unit = {
 	println("add 3 ints: {a + b + c}")
 }
 
-fn add*(a: f32, b: f32) = {
+fn add*(a: f32, b: f32) unit = {
 	unsafe printf("add floats: %f\n".ptr, a + b)
 }
 
-fn add*(a: int, b: f32) = {
+fn add*(a: int, b: f32) unit = {
 	unsafe printf("add int & f32: %f\n".ptr, f32(a) + b)
 }
 
-fn poly*[T](x: T) = {
+fn poly*[T](x: T) unit = {
 	unsafe printf("poly[a]: x = %d\n".ptr, x)
 }

--- a/tests/glob-imports.jin
+++ b/tests/glob-imports.jin
@@ -2,4 +2,4 @@ mod a
 
 use glob-imports.a.(*)
 
-fn main() = hello()
+fn main() unit = hello()

--- a/tests/glob-imports/a/b.jin
+++ b/tests/glob-imports/a/b.jin
@@ -1,3 +1,3 @@
 use std
 
-fn hello*() = std.io.println("Hello!")
+fn hello*() unit = std.io.println("Hello!")

--- a/tests/hello-world.jin
+++ b/tests/hello-world.jin
@@ -1,2 +1,2 @@
-fn main() =
+fn main() unit =
     std.io.println("Hello, World!")

--- a/tests/hello-world.jin
+++ b/tests/hello-world.jin
@@ -1,2 +1,3 @@
-fn main() unit =
-    std.io.println("Hello, World!")
+fn main() unit = {
+    println("Hello, World!")
+}

--- a/tests/hooks.jin
+++ b/tests/hooks.jin
@@ -1,9 +1,9 @@
-fn main() = {
+fn main() unit = {
     let mut wow = Wow("bye bye!")
     println("hello")
 }
 
 type Wow*(msg: &str)
 
-fn `=drop`(w: &mut Wow) =
+fn `=drop`(w: &mut Wow) unit =
     println(w.msg)

--- a/tests/imports.jin
+++ b/tests/imports.jin
@@ -5,7 +5,7 @@ use imports.bar.baz.yup
 use imports.bar.(*)
 use imports.ufcs.(?)
 
-fn main() = {
+fn main() unit = {
     hello()
     yup()
     goodbye()
@@ -15,4 +15,4 @@ fn main() = {
     //print-int(1) // Error!
 }
 
-fn get-hello-world*() -> &str = "Hello from bar!\n"
+fn get-hello-world*() &str = "Hello from bar!\n"

--- a/tests/imports/bar.jin
+++ b/tests/imports/bar.jin
@@ -2,12 +2,12 @@ mod baz*
 
 use imports as root
 
-fn extern "c" printf(fmt: ptr[u8], ..) -> i32
+fn extern "c" printf(fmt: ptr[u8], ..) i32
 
-fn hello*() = {
+fn hello*() unit = {
     unsafe printf(root.get-hello-world().ptr)
 }
 
-fn goodbye*() = {
+fn goodbye*() unit = {
     unsafe printf("Goodbye...\n".ptr)
 }

--- a/tests/imports/bar/baz.jin
+++ b/tests/imports/bar/baz.jin
@@ -1,5 +1,5 @@
-fn extern "c" printf(fmt: ptr[u8], ..) -> i32
+fn extern "c" printf(fmt: ptr[u8], ..) i32
 
-fn yup*() = {
+fn yup*() unit = {
 	unsafe printf("yup for baz :)\n".ptr)
 }

--- a/tests/imports/ufcs.jin
+++ b/tests/imports/ufcs.jin
@@ -1,5 +1,5 @@
-fn extern "c" printf(fmt: ptr[u8], ..) -> i32
+fn extern "c" printf(fmt: ptr[u8], ..) i32
 
-fn print-int*(value: int) = {
+fn print-int*(value: int) unit = {
 	unsafe printf("print-int: %d\n".ptr, value)
 }

--- a/tests/loop.jin
+++ b/tests/loop.jin
@@ -1,4 +1,4 @@
-fn main() = {
+fn main() unit = {
     for {
         println("Once")
         break

--- a/tests/overflow.jin
+++ b/tests/overflow.jin
@@ -1,12 +1,12 @@
 use std.int.(*)
 
-fn main() = {
+fn main() unit = {
     i()
     println()
     u()
 }
 
-fn i() = {
+fn i() unit = {
     println("signed:")
 
     let a: i64 = 1
@@ -17,7 +17,7 @@ fn i() = {
     // a * b
 }
 
-fn u() = {
+fn u() unit = {
     println("unsigned:")
 
     let a: u8 = 2

--- a/tests/ownership.jin
+++ b/tests/ownership.jin
@@ -1,9 +1,9 @@
-fn extern "c" printf(fmt: ptr[u8], ..) -> i32
+fn extern "c" printf(fmt: ptr[u8], ..) i32
 
 type Num(field: int)
 type Wrapper(num: Num)
 
-fn main() = {
+fn main() unit = {
     use-after-move()
     // use-after-move-scoped()
     // move-out-of-global()
@@ -13,13 +13,13 @@ fn main() = {
     // drop-discarded-values(Num(1))
 }
 
-fn use-after-move() = {
+fn use-after-move() unit = {
     let n = Num(1)
     let x = n
     //let y = n // Error!
 }
 
-fn use-after-move-scoped() = {
+fn use-after-move-scoped() unit = {
     let n = Num(1)
     let x = n
     if false {
@@ -30,12 +30,12 @@ fn use-after-move-scoped() = {
 let global-int: int = 1
 let global-num: Num = Num(1)
 
-fn move-out-of-global() = {
+fn move-out-of-global() unit = {
     let x = global-int // Ok
     //let y = global-num // Error!
 }
 
-fn move-into-for() = {
+fn move-into-for() unit = {
     let mut n = Num(1)
 
     for if n.field < 10 {
@@ -44,7 +44,7 @@ fn move-into-for() = {
     }
 }
 
-fn copy() = {
+fn copy() unit = {
     let n = 1
     let a = n
     let b = n // Ok
@@ -58,7 +58,7 @@ fn copy() = {
     let b = w.num.field // Ok
 }
 
-fn assign-not-moved() = {
+fn assign-not-moved() unit = {
     //let mut num = Num(1)
     //num.field = 1
 
@@ -87,6 +87,6 @@ fn assign-not-moved() = {
     }
 }
 
-fn drop-discarded-values(_: Num) = {
+fn drop-discarded-values(_: Num) unit = {
     let _ = Num(2)
 }

--- a/tests/pmatch.jin
+++ b/tests/pmatch.jin
@@ -1,8 +1,8 @@
 mod inner
 
-fn extern "c" printf(fmt: ptr[u8], ..) -> i32
+fn extern "c" printf(fmt: ptr[u8], ..) i32
 
-fn main() = {
+fn main() unit = {
     match-vars()
     match-unit()
     match-bool(true)
@@ -27,7 +27,7 @@ fn main() = {
     print-fib(20)
 }
 
-fn match-vars() = {
+fn match-vars() unit = {
     match true {
         mut x -> {
             x = false
@@ -41,14 +41,14 @@ fn match-vars() = {
 }
 
 
-fn match-unit() -> int = {
+fn match-unit() int = {
     match {} {
         {} -> unsafe printf("matched unit!\n".ptr)
         _ -> 1 // This branch is unreachable
     }
 }
 
-fn match-bool(value: bool) = {
+fn match-bool(value: bool) unit = {
     unsafe printf("value = %s\n".ptr, match value {
         true -> "true"
         false -> "false"
@@ -56,7 +56,7 @@ fn match-bool(value: bool) = {
     })
 }
 
-fn match-int(value: int) = {
+fn match-int(value: int) unit = {
     match value {
         42 -> unsafe printf("i'm the answer\n".ptr)
         -3 -> unsafe printf("i'm -3\n".ptr)
@@ -64,7 +64,7 @@ fn match-int(value: int) = {
     }
 }
 
-fn match-uint(value: uint) = {
+fn match-uint(value: uint) unit = {
     match value {
         42 -> unsafe printf("i'm still the answer\n".ptr)
         3 -> unsafe printf("i'm still 3\n".ptr)
@@ -72,7 +72,7 @@ fn match-uint(value: uint) = {
     }
 }
 
-fn match-str(value: &str) = {
+fn match-str(value: &str) unit = {
     match value {
         "foo" -> unsafe printf("i'm 'foo'\n".ptr)
         "bar" -> unsafe printf("i'm 'bar'\n".ptr)
@@ -84,7 +84,7 @@ fn match-str(value: &str) = {
 type Box(value: int)
 type Bag(a: Box, b: Box)
 
-fn match-types() = {
+fn match-types() unit = {
     let box = Box(1)
 
     match box {
@@ -112,11 +112,11 @@ fn match-types() = {
     // }
 }
 
-fn print(box: &Box) = {
+fn print(box: &Box) unit = {
     unsafe printf("Box(%d)\n".ptr, box.value)
 }
 
-fn print(bag: &Bag) = {
+fn print(bag: &Bag) unit = {
     match bag {
         Bag(a, b) -> {
             unsafe printf("Bag(a: Box(%d), b: Box(%d))\n".ptr, a.value, b.value)
@@ -125,13 +125,13 @@ fn print(bag: &Bag) = {
     }
 }
 
-fn print(value: int) = {
+fn print(value: int) unit = {
     unsafe printf("%d\n".ptr, value)
 }
 
-fn drop(box: Box) = {}
+fn drop(box: Box) unit = {}
 
-fn match-guard() = {
+fn match-guard() unit = {
     let foo = true
     match foo {
         _ if foo -> { unsafe printf("foo=true (guard)\n".ptr) }
@@ -141,21 +141,21 @@ fn match-guard() = {
     }
 }
 
-fn print-fac(n: int) = {
-    unsafe printf("fac(%d) = %d\n".ptr, n, fac(n))
+fn print-fac(n: int) unit = {
+    unsafe printf("fac(%d) unit = %d\n".ptr, n, fac(n))
 }
 
-fn fac(n: int) -> int =
+fn fac(n: int) int =
     match n {
         0 | 1 -> 1
         n -> n * fac(n - 1)
     }
 
-fn print-fib(n: int) = {
-    unsafe printf("fib(%d) = %d\n".ptr, n, fib(n))
+fn print-fib(n: int) unit = {
+    unsafe printf("fib(%d) unit = %d\n".ptr, n, fib(n))
 }
 
-fn fib(n: int) -> int =
+fn fib(n: int) int =
     match n {
         0 | 1 -> n
         n -> fib(n - 1) + fib(n - 2)

--- a/tests/pmatch.jin
+++ b/tests/pmatch.jin
@@ -43,7 +43,7 @@ fn match-vars() = {
 
 fn match-unit() -> int = {
     match {} {
-        () -> unsafe printf("matched unit!\n".ptr)
+        {} -> unsafe printf("matched unit!\n".ptr)
         _ -> 1 // This branch is unreachable
     }
 }

--- a/tests/pmatch.jin
+++ b/tests/pmatch.jin
@@ -42,7 +42,7 @@ fn match-vars() = {
 
 
 fn match-unit() -> int = {
-    match () {
+    match {} {
         () -> unsafe printf("matched unit!\n".ptr)
         _ -> 1 // This branch is unreachable
     }
@@ -90,8 +90,8 @@ fn match-types() = {
     match box {
         Box(1) -> { unsafe printf("it's 1!\n".ptr) }
         Box(v) -> print(v)
-        Box(_) -> () // unreachable
-        _ -> () // unreachable
+        Box(_) -> {} // unreachable
+        _ -> {} // unreachable
     }
 
     let bag = Bag(Box(1), Box(3))
@@ -101,14 +101,14 @@ fn match-types() = {
         Bag(b: Box(3), a: Box(a)) -> { unsafe printf("a: %d, b: 3 (named)\n".ptr, a) }
         Bag(Box(a), Box(3)) -> { unsafe printf("a: %d, b: 3\n".ptr, a) }
         Bag(a, ..) -> drop(a)
-        _ -> () // unreachable
+        _ -> {} // unreachable
     }
 
     // print(bag)
 
     // match inner.get(1) {
-    //  //inner.Inner(field: 1) -> () // Error: match private field
-    //  inner.Inner(..) -> () // Ok, field isn't used
+    //  //inner.Inner(field: 1) -> {} // Error: match private field
+    //  inner.Inner(..) -> {} // Ok, field isn't used
     // }
 }
 

--- a/tests/pmatch/inner.jin
+++ b/tests/pmatch/inner.jin
@@ -1,3 +1,3 @@
 type Inner*(field: int)
 
-fn get*(field: int) -> Inner = Inner(field)
+fn get*(field: int) Inner = Inner(field)

--- a/tests/pmatch2.jin
+++ b/tests/pmatch2.jin
@@ -1,4 +1,4 @@
-fn main() = {
+fn main() unit = {
     match 20 {
         10 | 20 if false -> println("guard")
         10 -> println("10")

--- a/tests/poly-types.jin
+++ b/tests/poly-types.jin
@@ -1,10 +1,10 @@
 mod inner
 
-fn extern "c" printf(fmt: ptr[u8], ..) -> i32
+fn extern "c" printf(fmt: ptr[u8], ..) i32
 
 type Box[T](value: T)
 
-fn main() = {
+fn main() unit = {
     print(&Box(1).value) // matches print(int)
     print(&Box(3.0).value) // matches print(f32)
     print(&Box(42)) // matches print(&Box[int])
@@ -13,22 +13,22 @@ fn main() = {
     print(&inner.Inner[int](30)) // matches print(&inner.Inner[int])
 }
 
-fn print(value: int) = {
+fn print(value: int) unit = {
     println("{value}")
 }
 
-fn print(value: f32) = {
+fn print(value: f32) unit = {
     unsafe printf("%f\n".ptr, value)
 }
 
-fn print(box: &Box[int]) = {
+fn print(box: &Box[int]) unit = {
     println("Box({box.value})")
 }
 
-fn print[T](box: &Box[T]) = {
+fn print[T](box: &Box[T]) unit = {
     unsafe printf("Box(%f)\n".ptr, &box.value)
 }
 
-fn print(inner: &inner.Inner[int]) = {
+fn print(inner: &inner.Inner[int]) unit = {
     println("Inner({inner.value})")
 }

--- a/tests/priv.jin
+++ b/tests/priv.jin
@@ -4,4 +4,4 @@ mod c
 use priv.b.val as vb
 use priv.c.val as vc
 
-fn main() = {}
+fn main() unit = {}

--- a/tests/raylib.jin
+++ b/tests/raylib.jin
@@ -3,7 +3,7 @@ mod input-keys
 mod following-eyes
 mod bindings
 
-fn main() = {
+fn main() unit = {
     // basic-window.run()
     // input-keys.run()
     // following-eyes.run()

--- a/tests/raylib/basic-window.jin
+++ b/tests/raylib/basic-window.jin
@@ -1,6 +1,6 @@
 use raylib.bindings.(*)
 
-fn run*() = unsafe {
+fn run*() unit = unsafe {
 	let screen-width = 800
 	let screen-height = 450
 

--- a/tests/raylib/bindings.jin
+++ b/tests/raylib/bindings.jin
@@ -1,18 +1,18 @@
 mod extern "raylib"
 mod extern "m"
 
-fn extern "c" InitWindow*(width: i32, height: i32, title: ptr[u8])
-fn extern "c" CloseWindow*()
-fn extern "c" WindowShouldClose*() -> bool
-fn extern "c" SetTargetFPS*(fps: i32)
-fn extern "c" BeginDrawing*()
-fn extern "c" EndDrawing*()
-fn extern "c" ClearBackground*(color: Color)
-fn extern "c" DrawCircle*(center-x: i32, center-y: i32, radius: f32, color: Color)
-fn extern "c" DrawCircleV*(center: Vector2, radius: f32, color: Color)
-fn extern "c" DrawRectangle*(pos-x: i32, pos-y: i32, width: i32, height: i32, color: Color)
-fn extern "c" DrawFPS*(pos-x: i32, pos-y: i32)
-fn extern "c" DrawText*(text: ptr[u8], pos-x: i32, pos-y: i32, font-size: i32, tint: Color)
+fn extern "c" InitWindow*(width: i32, height: i32, title: ptr[u8]) unit
+fn extern "c" CloseWindow*() unit
+fn extern "c" WindowShouldClose*() bool
+fn extern "c" SetTargetFPS*(fps: i32) unit
+fn extern "c" BeginDrawing*() unit
+fn extern "c" EndDrawing*() unit
+fn extern "c" ClearBackground*(color: Color) unit
+fn extern "c" DrawCircle*(center-x: i32, center-y: i32, radius: f32, color: Color) unit
+fn extern "c" DrawCircleV*(center: Vector2, radius: f32, color: Color) unit
+fn extern "c" DrawRectangle*(pos-x: i32, pos-y: i32, width: i32, height: i32, color: Color) unit
+fn extern "c" DrawFPS*(pos-x: i32, pos-y: i32) unit
+fn extern "c" DrawText*(text: ptr[u8], pos-x: i32, pos-y: i32, font-size: i32, tint: Color) unit
 
 type Color* extern(r*: u8, g*: u8, b*: u8, a*: u8)
 
@@ -26,12 +26,12 @@ let DARKGREEN*: Color = Color(0, 117, 44, 255)
 
 type Vector2* extern(x*: f32, y*: f32)
 
-fn extern "c" GetMousePosition*() -> Vector2
-fn extern "c" IsKeyDown*(key: i32) -> bool
+fn extern "c" GetMousePosition*() Vector2
+fn extern "c" IsKeyDown*(key: i32) bool
 
 let KEY-RIGHT*: i32 = 262
 let KEY-LEFT*: i32 = 263
 let KEY-DOWN*: i32 = 264
 let KEY-UP*: i32 = 265
 
-fn extern "c" CheckCollisionPointCircle*(point: Vector2, center: Vector2, radius: f32) -> bool
+fn extern "c" CheckCollisionPointCircle*(point: Vector2, center: Vector2, radius: f32) bool

--- a/tests/raylib/following-eyes.jin
+++ b/tests/raylib/following-eyes.jin
@@ -1,11 +1,11 @@
 use raylib.bindings.(*)
 
-fn extern "c" printf(fmt: ptr[u8], ..) -> i32
-fn extern "c" atan2f(y: f32, x: f32) -> f32
-fn extern "c" cosf(arg: f32) -> f32
-fn extern "c" sinf(arg: f32) -> f32
+fn extern "c" printf(fmt: ptr[u8], ..) i32
+fn extern "c" atan2f(y: f32, x: f32) f32
+fn extern "c" cosf(arg: f32) f32
+fn extern "c" sinf(arg: f32) f32
 
-fn run*() = unsafe {
+fn run*() unit = unsafe {
 	let screen-width = 800
 	let screen-height = 450
 

--- a/tests/raylib/input-keys.jin
+++ b/tests/raylib/input-keys.jin
@@ -1,6 +1,6 @@
 use raylib.bindings.(*)
 
-fn run*() = unsafe {
+fn run*() unit = unsafe {
 	let screen-width = 800
 	let screen-height = 450
 

--- a/tests/ref-vs-value.jin
+++ b/tests/ref-vs-value.jin
@@ -1,4 +1,4 @@
-fn main() = {
+fn main() unit = {
 	println("Reference semantics:")
 	ref-type()
 	println()
@@ -9,7 +9,7 @@ fn main() = {
 
 type Ref(field: int)
 
-fn ref-type() = {
+fn ref-type() unit = {
 	let mut r = Ref(1)
 	print(&r) // should be 1
 
@@ -20,17 +20,17 @@ fn ref-type() = {
 	print(&r) // should be 3
 }
 
-fn mutate(r: &mut Ref) = {
+fn mutate(r: &mut Ref) unit = {
 	r.field = 3
 }
 
-fn print(r: &Ref) = {
+fn print(r: &Ref) unit = {
 	println("Ref(field: {r.field})")
 }
 
 type Ext extern(field: int)
 
-fn ext-type() = {
+fn ext-type() unit = {
 	let mut ext = Ext(1)
 	print(ext) // should be 1
 
@@ -41,11 +41,11 @@ fn ext-type() = {
 	print(ext) // should still be 2
 }
 
-fn mutate(mut ext: Ext) = {
+fn mutate(mut ext: Ext) unit = {
 	ext.field = 3
 }
 
-fn print(ext: Ext) = {
+fn print(ext: Ext) unit = {
 	println("Ext(field: {ext.field})")
 }
 

--- a/tests/references.jin
+++ b/tests/references.jin
@@ -1,11 +1,11 @@
-fn extern "c" printf(fmt: ptr[u8], ..) -> i32
+fn extern "c" printf(fmt: ptr[u8], ..) i32
 
 type Box(value: int)
 type Ref(box: &Box)
 type Mut(box: &mut Box)
 type Bag(a: Box, b: Box)
 
-fn main() = {
+fn main() unit = {
     let mut box = Box(1)
     box.print() // Coerced to &Box
     box.set(42) // Coerced to &mut Box
@@ -33,11 +33,11 @@ fn main() = {
     rmut.box.value = 2
 }
 
-fn print(box: &Box) = {
+fn print(box: &Box) unit = {
     unsafe printf("Box(%d)\n".ptr, box.value)
 }
 
-fn set(box: &mut Box, value: int) =
+fn set(box: &mut Box, value: int) unit =
     box.value = value
 
-fn copy(bag: Bag) -> Bag = Bag(bag.a, bag.b)
+fn copy(bag: Bag) Bag = Bag(bag.a, bag.b)

--- a/tests/result-type.jin
+++ b/tests/result-type.jin
@@ -1,13 +1,13 @@
-fn extern "c" printf(fmt: ptr[u8], ..) -> i32
+fn extern "c" printf(fmt: ptr[u8], ..) i32
 
-fn main() = {
+fn main() unit = {
     match try-add(1, 2) {
         Result.Ok(res) -> unsafe printf("res = %d\n".ptr, res)
         Result.Err(msg) -> unsafe printf(msg.ptr)
     }
 }
 
-fn try-add(a: int, b: int) -> Result[int, &str] = {
+fn try-add(a: int, b: int) Result[int, &str] = {
     if a == b {
         Result.Ok(a + b)
     } else {

--- a/tests/slices.jin
+++ b/tests/slices.jin
@@ -1,13 +1,13 @@
 use std.builtin
 
-fn extern "c" printf(fmt: ptr[u8], ..) -> i32
+fn extern "c" printf(fmt: ptr[u8], ..) i32
 
-fn main() = {
+fn main() unit = {
     ints()
     boxes()
 }
 
-fn ints() = {
+fn ints() unit = {
     let a: []int = []
     print(&a)
 
@@ -40,7 +40,7 @@ fn ints() = {
     print(&c.[..])
 }
 
-fn print(s: &[]int) = {
+fn print(s: &[]int) unit = {
     print("[")
     let mut i = 0
     for if i < s.len {
@@ -55,14 +55,14 @@ fn print(s: &[]int) = {
 
 type Box(value: int)
 
-fn boxes() = {
+fn boxes() unit = {
     let a = [Box(1), Box(2), Box(3)]
     let b = &a.[0]
     let c = &a.[0]
     let nested = [[Box(1), Box(2)], [Box(3)]]
 }
 
-fn push[T](slice: &mut []T, value: T) = {
+fn push[T](slice: &mut []T, value: T) unit = {
     unsafe slice.len += 1
     slice.[slice.len - 1] = value
 }

--- a/tests/sm-demo.jin
+++ b/tests/sm-demo.jin
@@ -1,4 +1,4 @@
-fn main() = {
+fn main() unit = {
     int-types()
     unary()
     arithmetic()
@@ -10,7 +10,7 @@ fn main() = {
     global-vars()
 }
 
-fn int-types() = {
+fn int-types() unit = {
     let id: i8 = 126
     let promoted = i64(id) + 5555
     let demoted1 = i32(promoted)
@@ -18,14 +18,14 @@ fn int-types() = {
     let int-to-uint = uint(int(663151))
 }
 
-fn unary() = {
+fn unary() unit = {
     -48
     !true
     !!false
     !54878
 }
 
-fn arithmetic() = {
+fn arithmetic() unit = {
     1 + 2
     3 - 4
     5 * 6
@@ -33,7 +33,7 @@ fn arithmetic() = {
     9 % 10
 }
 
-fn cmp() = {
+fn cmp() unit = {
     true && false
     false || true
     100 == 100
@@ -44,7 +44,7 @@ fn cmp() = {
     264 >= 71
 }
 
-fn if-expr() = {
+fn if-expr() unit = {
     let cond = true
     let result = if cond {
         69
@@ -53,18 +53,18 @@ fn if-expr() = {
     }
 }
 
-fn variables() -> int = {
+fn variables() int = {
     let x = 7 // Inferred to `int`
     let y: int = 3 // Explicit type annotation
     let x = 39  // Variables can be shadowed
     x + y
 }
 
-fn id[T](x: T) -> T = {
+fn id[T](x: T) T = {
     x
 }
 
-fn polymorphism() = {
+fn polymorphism() unit = {
     // Inferred type arguments
     id(42)
     id(true)
@@ -74,11 +74,11 @@ fn polymorphism() = {
     id[bool](false)
 }
 
-fn add-named(~first: int, ~second: int) -> int = {
+fn add-named(~first: int, ~second: int) int = {
     first + second
 }
 
-fn named-args() = {
+fn named-args() unit = {
     add-named(first: 1, second: 2)
     add-named(second: 2, first: 1)
     add-named(1, second: 2)
@@ -86,6 +86,6 @@ fn named-args() = {
 
 let global-answer: int = 42
 
-fn global-vars() = {
+fn global-vars() unit = {
     let answer = global-answer
 }

--- a/tests/str-interp.jin
+++ b/tests/str-interp.jin
@@ -1,6 +1,6 @@
 use std.int.(Format)
 
-fn main() = {
+fn main() unit = {
     let letter = "R"
     let n = 18
     println("{letter} is the {n}th letter of the alphabet.")

--- a/tests/strbuf-test.jin
+++ b/tests/strbuf-test.jin
@@ -1,6 +1,6 @@
-fn extern "c" printf(fmt: ptr[u8], ..) -> i32
+fn extern "c" printf(fmt: ptr[u8], ..) i32
 
-fn main() = {
+fn main() unit = {
 	let mut b = StrBuf.new()
 	print-str(&b)
 
@@ -30,5 +30,5 @@ fn main() = {
 	unsafe printf("\n".ptr)
 }
 
-fn print-str(b: &StrBuf) =
+fn print-str(b: &StrBuf) unit =
 	unsafe printf("str is: '%s'\n".ptr, b.as-ref().ptr)

--- a/tests/strs.jin
+++ b/tests/strs.jin
@@ -1,6 +1,6 @@
-fn extern "c" printf(fmt: ptr[u8], ..) -> i32
+fn extern "c" printf(fmt: ptr[u8], ..) i32
 
-fn main() = {
+fn main() unit = {
     let mut s = "Hello World"
     println(s)
 
@@ -16,6 +16,6 @@ fn main() = {
     println(&s.[3..10])
 }
 
-fn print-at(s: &str, at: uint) = {
+fn print-at(s: &str, at: uint) unit = {
     unsafe printf("s.[%d] = %c\n".ptr, at, s.[at])
 }

--- a/tests/swap-op.jin
+++ b/tests/swap-op.jin
@@ -1,6 +1,6 @@
-fn extern "c" printf(fmt: ptr[u8], ..) -> i32
+fn extern "c" printf(fmt: ptr[u8], ..) i32
 
-fn main() = {
+fn main() unit = {
     let mut a = 1
     print(a)
     let old = a := 2
@@ -8,5 +8,5 @@ fn main() = {
     print(old)
 }
 
-fn print(v: int) =
+fn print(v: int) unit =
     unsafe printf("%d\n".ptr, v)

--- a/tests/test.jin
+++ b/tests/test.jin
@@ -1,11 +1,11 @@
 mod extern "./foo"
 
-fn extern "c" hello()
+fn extern "c" hello() unit
 let extern answer: int
 
-fn extern "c" printf(fmt: ptr[u8], ..) -> i32
+fn extern "c" printf(fmt: ptr[u8], ..) i32
 
-fn main() = {
+fn main() unit = {
     println("Hello, World!")
     unsafe hello()
     run(print-answer)
@@ -13,21 +13,21 @@ fn main() = {
     unsafe printf("num = %d\n".ptr, map(1, id))
 }
 
-fn print-answer() = {
+fn print-answer() unit = {
     unsafe printf("The answer is %d\n".ptr, answer)
 }
 
-fn add(a: int, b: int) -> int = {
+fn add(a: int, b: int) int = {
     a + b
 }
 
-fn do-add(f: fn(int, int) -> int, a: int, b: int) = {
+fn do-add(f: fn(int, int) int, a: int, b: int) unit = {
     unsafe printf("a + b = %d\n".ptr, f(a, b))
 }
 
-fn run(f: fn()) = f()
+fn run(f: fn() unit) unit = f()
 
-fn id[T](x: T) -> T = x
+fn id[T](x: T) T = x
 
-fn map[A, B](val: A, f: fn(A) -> B) -> B =
+fn map[A, B](val: A, f: fn(A) B) B =
     f(val)

--- a/tests/typealias.jin
+++ b/tests/typealias.jin
@@ -1,7 +1,7 @@
 type Fd = uint
 type Ref[T] = &T
 
-fn main() = {
+fn main() unit = {
     let x: Fd = Fd(1)
     let r: Ref[int] = &1
 }

--- a/tests/union-move.jin
+++ b/tests/union-move.jin
@@ -1,4 +1,4 @@
-fn extern "c" printf(fmt: ptr[u8], ..) -> i32
+fn extern "c" printf(fmt: ptr[u8], ..) i32
 
 type Move()
 type Enum {
@@ -17,7 +17,7 @@ type PolyRef[T] {
     R(r: &T)
 }
 
-fn main() = {
+fn main() unit = {
     // Copy
     let enum = Enum.Foo
     let enum2 = enum

--- a/tests/union.jin
+++ b/tests/union.jin
@@ -1,6 +1,6 @@
 type Box(value: int)
 
-fn main() = {
+fn main() unit = {
     // Value constructors
     let a = Option.Some(1)
     let b = Option[int].Some(1)
@@ -38,4 +38,4 @@ fn main() = {
     }
 }
 
-fn is-negative(x: int) -> bool = x < 0
+fn is-negative(x: int) bool = x < 0

--- a/tests/valgrind.jin
+++ b/tests/valgrind.jin
@@ -1,11 +1,11 @@
-fn extern "c" printf(fmt: ptr[u8], ..) -> i32
+fn extern "c" printf(fmt: ptr[u8], ..) i32
 
 type Num(field: int)
 type Wrapper(num: Num)
 type Duo(n1: Num, n2: Num)
 type WrapperDuo(w1: Wrapper, w2: Wrapper)
 
-fn main() = {
+fn main() unit = {
     // Drop temporary values
     Num(1)
     Wrapper(Num(1))
@@ -61,4 +61,4 @@ fn main() = {
     }
 }
 
-fn drop-poly[T](arg: T) = {}
+fn drop-poly[T](arg: T) unit = {}

--- a/tests/value-types.jin
+++ b/tests/value-types.jin
@@ -1,4 +1,4 @@
-fn extern "c" printf(fmt: ptr[u8], ..) -> i32
+fn extern "c" printf(fmt: ptr[u8], ..) i32
 
 type M()
 
@@ -8,7 +8,7 @@ type Mixed extern(a: Ref)
 
 type Point extern(x: int, y: int)
 
-fn main() = {
+fn main() unit = {
 	let m = M()
 	let m2 = m
 	// let m3 = m // Error: use after move
@@ -24,6 +24,6 @@ fn main() = {
 	print-point(Point(5, y: 10))
 }
 
-fn print-point(p: Point) = {
+fn print-point(p: Point) unit = {
 	unsafe printf("Point(%d, %d)\n".ptr, p.x, p.y)
 }

--- a/tests/vis.jin
+++ b/tests/vis.jin
@@ -1,8 +1,8 @@
 mod child
 
-fn main() = {}
+fn main() unit = {}
 
-fn a() = child.Priv(1)
-fn b() = child.PrivCtor(1)
+fn a() unit = child.Priv(1)
+fn b() unit = child.PrivCtor(1)
 
-fn x() = {}
+fn x() unit = {}

--- a/tests/vis/child.jin
+++ b/tests/vis/child.jin
@@ -3,7 +3,7 @@ use vis
 type Priv(num: int)
 type PrivCtor*(num: int)
 
-fn foo() = {
+fn foo() unit = {
     Priv(1).num
     vis.x()
 }


### PR DESCRIPTION
- Remove the need for `->` in return types, so `fn() -> int` is now spelled `fn() int`.
- Change the unit type from `()` to `unit`.
- Remove explicit unit value `()`. An empty block `{}` can be used instead.
- Change unit pattern `()` to `{}`.